### PR TITLE
Add support for BIR API version 1.2 and usage example

### DIFF
--- a/RegonAPI/consts/bir_version_maps.py
+++ b/RegonAPI/consts/bir_version_maps.py
@@ -21,81 +21,136 @@ BIR_SETTINGS = {
             "WSDL": "https://wyszukiwarkaregon.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl-ver11-prod.wsdl",
         },
     },
+    "bir1.2": {  # BIR1.2
+        "TEST": {
+            "SERVICE_URL": "https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc",
+            "WSDL": "https://wyszukiwarkaregontest.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl-ver11-test.wsdl",
+        },
+        "PROD": {
+            "SERVICE_URL": "https://wyszukiwarkaregon.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc",
+            # No correction in version 1.1
+            "WSDL": "https://wyszukiwarkaregon.stat.gov.pl/wsBIR/wsdl/UslugaBIRzewnPubl-ver11-prod.wsdl",
+        },
+    },
 }
 
 BIR_VERSIONS = BIR_SETTINGS.keys()
 
 OPERATIONS = {
-    "alias_search_data": {"bir1": "DaneSzukaj", "bir1.1": "DaneSzukajPodmioty"},
+    "alias_search_data": {"bir1": "DaneSzukaj", "bir1.1": "DaneSzukajPodmioty", "bir1.2": "DaneSzukajPodmioty"},
     "alias_data_download_full_report": {
         "bir1": "DanePobierzPelnyRaport",
         "bir1.1": "DanePobierzPelnyRaport",
+        "bir1.2": "DanePobierzPelnyRaport"
     },
     "alias_data_download_full_group_report": {
         "bir1": NotImplementedError,
         "bir1.1": "DanePobierzRaportZbiorczy",
+        "bir1.2": "DanePobierzRaportZbiorczy"
     },
 }
 
 # DanePobierzPelnyRaport - settings
 DANE_POBIERZ_PELNY_RAPORT_REPORT_NAMES = [
-    {"bir1": "PublDaneRaportFizycznaOsoba", "bir1.1": "BIR11OsFizycznaDaneOgolne"},
+    {
+        "bir1": "PublDaneRaportFizycznaOsoba", 
+        "bir1.1": "BIR11OsFizycznaDaneOgolne",
+        "bir1.2": "BIR12OsFizycznaDaneOgolne"
+    },
     {
         "bir1": "PublDaneRaportDzialalnoscFizycznejCeidg",
         "bir1.1": "BIR11OsFizycznaDzialalnoscCeidg",
+        "bir1.2": "BIR12OsFizycznaDzialalnoscCeidg",
     },
     {
         "bir1": "PublDaneRaportDzialalnoscFizycznejRolnicza",
         "bir1.1": "BIR11OsFizycznaDzialalnoscRolnicza",
+        "bir1.2": "BIR12OsFizycznaDzialalnoscRolnicza"
     },
     {
         "bir1": "PublDaneRaportDzialalnoscFizycznejPozostala",
         "bir1.1": "BIR11OsFizycznaDzialalnoscPozostala",
+        "bir1.2": "BIR12OsFizycznaDzialalnoscPozostala"
     },
     {
         "bir1": "PublDaneRaportDzialalnoscFizycznejWKrupgn",
         "bir1.1": "BIR11OsFizycznaDzialalnoscSkreslonaDo20141108",
+        "bir1.2": "BIR12OsFizycznaDzialalnoscSkreslonaDo20141108"
     },
-    {"bir1": "PublDaneRaportDzialalnosciFizycznej", "bir1.1": "BIR11OsFizycznaPkd"},
+    {
+        "bir1": "PublDaneRaportDzialalnosciFizycznej",
+        "bir1.1": "BIR11OsFizycznaPkd",
+        "bir1.2": "BIR12OsFizycznaPkd"
+    },
     {
         "bir1": "PublDaneRaportLokalneFizycznej",
         "bir1.1": "BIR11OsFizycznaListaJednLokalnych",
+        "bir1.2": "BIR12OsFizycznaListaJednLokalnych"
+
     },
-    {"bir1": "PublDaneRaportLokalnaFizycznej", "bir1.1": "BIR11JednLokalnaOsFizycznej"},
+    {
+        "bir1": "PublDaneRaportLokalnaFizycznej",
+        "bir1.1": "BIR11JednLokalnaOsFizycznej",
+        "bir1.2": "BIR12JednLokalnaOsFizycznej"
+    },
     {
         "bir1": "PublDaneRaportDzialalnosciLokalnejFizycznej",
         "bir1.1": "BIR11JednLokalnaOsFizycznejPkd",
+        "bir1.2": "BIR12JednLokalnaOsFizycznejPkd"
     },
-    {"bir1": "PublDaneRaportPrawna", "bir1.1": "BIR11OsPrawna"},
-    {"bir1": "PublDaneRaportDzialalnosciPrawnej", "bir1.1": "BIR11OsPrawnaPkd"},
+    {
+        "bir1": "PublDaneRaportPrawna",
+        "bir1.1": "BIR11OsPrawna",
+        "bir1.2": "BIR12OsPrawna"
+
+    },
+    {
+        "bir1": "PublDaneRaportDzialalnosciPrawnej",
+        "bir1.1": "BIR11OsPrawnaPkd", 
+        "bir1.2": "BIR12OsPrawnaPkd"
+    },
     {
         "bir1": "PublDaneRaportLokalnePrawnej",
         "bir1.1": "BIR11OsPrawnaListaJednLokalnych",
+        "bir1.2": "BIR12OsPrawnaListaJednLokalnych"
     },
-    {"bir1": "PublDaneRaportLokalnaPrawnej", "bir1.1": "BIR11JednLokalnaOsPrawnej"},
+    {
+        "bir1": "PublDaneRaportLokalnaPrawnej",
+        "bir1.1": "BIR11JednLokalnaOsPrawnej",
+        "bir1.2": "BIR12JednLokalnaOsPrawnej"
+        
+    },
     {
         "bir1": "PublDaneRaportDzialalnosciLokalnejPrawnej",
         "bir1.1": "BIR11JednLokalnaOsPrawnejPkd",
+        "bir1.2": "BIR12JednLokalnaOsPrawnejPkd"
     },
     {
         "bir1": "PublDaneRaportWspolnicyPrawnej",
         "bir1.1": "BIR11OsPrawnaSpCywilnaWspolnicy",
+        "bir1.2": "BIR12OsPrawnaSpCywilnaWspolnicy"
     },
-    {"bir1": "PublDaneRaportTypJednostki", "bir1.1": "BIR11TypPodmiotu"},
+    {
+        "bir1": "PublDaneRaportTypJednostki", 
+        "bir1.1": "BIR11TypPodmiotu", 
+        "bir1.2": "BIR12TypPodmiotu"
+    },
 ]
 
 # DanePobierzRaportZbiorczy - settings
 DANE_POBIERZ_RAPORT_ZBIORCZY_REPORT_NAMES = [
-    {"bir1.1": "BIR11NowePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
-    {"bir1.1": "BIR11AktualizowanePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
-    {"bir1.1": "BIR11SkreslonePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
-    {"bir1.1": "BIR11NoweJednostkiLokalne"},
-    {"bir1.1": "BIR11AktualizowaneJednostkiLokalne"},
-    {"bir1.1": "BIR11SkresloneJednostkiLokalne"},
+    {"bir1.1": "BIR11NowePodmiotyPrawneOrazDzialalnosciOsFizycznych", "bir1.2": "BIR11NowePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
+    {"bir1.1": "BIR11AktualizowanePodmiotyPrawneOrazDzialalnosciOsFizycznych", "bir1.2": "BIR11AktualizowanePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
+    {"bir1.1": "BIR11SkreslonePodmiotyPrawneOrazDzialalnosciOsFizycznych", "bir1.2": "BIR11SkreslonePodmiotyPrawneOrazDzialalnosciOsFizycznych"},
+    {"bir1.1": "BIR11NoweJednostkiLokalne", "bir1.2": "BIR11NoweJednostkiLokalne"},
+    {"bir1.1": "BIR11AktualizowaneJednostkiLokalne", "bir1.2": "BIR11AktualizowaneJednostkiLokalne" },
+    {"bir1.1": "BIR11SkresloneJednostkiLokalne", "bir1.2": "BIR11SkresloneJednostkiLokalne"},
 ]
 
 REPORTS = {
     "bir1": [x["bir1"] for x in DANE_POBIERZ_PELNY_RAPORT_REPORT_NAMES],
     "bir1.1": [x["bir1.1"] for x in DANE_POBIERZ_PELNY_RAPORT_REPORT_NAMES]
     + [x["bir1.1"] for x in DANE_POBIERZ_RAPORT_ZBIORCZY_REPORT_NAMES],
+    "bir1.2": [x["bir1.2"] for x in DANE_POBIERZ_PELNY_RAPORT_REPORT_NAMES]
+    + [x["bir1.2"] for x in DANE_POBIERZ_RAPORT_ZBIORCZY_REPORT_NAMES]
 }

--- a/examples/bir12_examples.py
+++ b/examples/bir12_examples.py
@@ -1,0 +1,79 @@
+from pprint import pprint
+
+from RegonAPI import RegonAPI
+from RegonAPI.exceptions import ApiAuthenticationError
+
+# Available reports
+REPORTS = [
+    "BIR12OsFizycznaDaneOgolne",
+    "BIR12OsFizycznaDzialalnoscCeidg",
+    "BIR12OsFizycznaDzialalnoscRolnicza",
+    "BIR12OsFizycznaDzialalnoscPozostala",
+    "BIR12OsFizycznaDzialalnoscSkreslonaDo20141108",
+    "BIR12OsFizycznaPkd",
+    "BIR12OsFizycznaListaJednLokalnych",
+    "BIR12JednLokalnaOsFizycznej",
+    "BIR12JednLokalnaOsFizycznejPkd",
+    "BIR12OsPrawna",
+    "BIR12OsPrawnaPkd",
+    "BIR12OsPrawnaListaJednLokalnych",
+    "BIR12JednLokalnaOsPrawnej",
+    "BIR12JednLokalnaOsPrawnejPkd",
+    "BIR12OsPrawnaSpCywilnaWspolnicy",
+    "BIR12TypPodmiotu",
+]
+
+TEST_API_KEY = "abcde12345abcde12345"
+CD_PROJEKT_NIP = "7342867148"
+CD_PROJEKT_KRS = "0000006865"
+CD_PROJEKT_REGON9 = "492707333"
+
+# Authentication
+api = RegonAPI(
+    bir_version="bir1.2", is_production=False, timeout=10, operation_timeout=10
+)
+try:
+    api.authenticate(key=TEST_API_KEY)
+except ApiAuthenticationError as e:
+    print("[-]", e)
+    exit(0)
+except Exception as e:
+    raise
+
+# Search by NIP
+result = api.searchData(nip=CD_PROJEKT_NIP)
+pprint(result)
+
+# Search by KRS
+result = api.searchData(krs=CD_PROJEKT_KRS)
+pprint(result)
+
+# Search by REGON
+result = api.searchData(regon=CD_PROJEKT_REGON9)
+pprint(result)
+
+# Get all reports by REGON
+for report_name in REPORTS:
+    result = api.dataDownloadFullReport(CD_PROJEKT_REGON9, report_name)
+    print("\n[*] Report:\n", report_name)
+    pprint(result)
+
+# Group reports
+
+GROUP_REPORTS = [
+    "BIR11NowePodmiotyPrawneOrazDzialalnosciOsFizycznych",
+    "BIR11AktualizowanePodmiotyPrawneOrazDzialalnosciOsFizycznych",
+    "BIR11SkreslonePodmiotyPrawneOrazDzialalnosciOsFizycznych",
+    "BIR11NoweJednostkiLokalne",
+    "BIR11AktualizowaneJednostkiLokalne",
+    "BIR11SkresloneJednostkiLokalne",
+]
+
+# It's better to fetch group reports using your own API key
+print("\n[!] It's better to fetch group reports using your own API key")
+exit(0)
+
+for group_report_name in GROUP_REPORTS:
+    result = api.dataDownloadFullGroupReport("2021-04-16", group_report_name)
+    print("\n[*] Group Report:\n", group_report_name)
+    pprint(result)


### PR DESCRIPTION
## Summary
This PR adds support for BIR API version 1.2 and provides an example demonstrating its usage.

## Changes
- Updated version mappings in `RegonAPI/consts/bir_version_maps.py`
- Added a new example script: `examples/bir12_examples.py`

## Motivation
The BIR API has been updated to version 1.2. This change ensures compatibility with the latest version and provides a reference example for developers.

## How to Test
1. Install dependencies:
   ```bash
   pip install -r requirements.txt
   ```
2. Run the example:
   ```bash
   python examples/bir12_examples.py
   ```

3. Verify that the script returns valid data from the BIR API.

## Compatibility
Backward compatible: Yes
No breaking changes introduced.